### PR TITLE
added test to not modify existing feature flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.code/
+.DS_Store
+.idea/
 build
 composer.lock
 vendor

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "francescomalatesta/laravel-feature",
+    "name": "onlinemeded/laravel-feature",
     "type": "library",
     "description": "A simple package to manage feature flagging in a Laravel project.",
     "keywords": ["laravel", "feature", "flag"],

--- a/src/Repository/EloquentFeatureRepository.php
+++ b/src/Repository/EloquentFeatureRepository.php
@@ -20,7 +20,7 @@ class EloquentFeatureRepository implements FeatureRepositoryInterface
         }
 
         $model->name = $feature->getName();
-        $model->is_enabled = $feature->isEnabled();
+        $model->is_enabled = $model->is_enabled ?? $feature->isEnabled();
 
         try {
             $model->save();

--- a/tests/Integration/Repository/EloquentFeatureRepositoryTest.php
+++ b/tests/Integration/Repository/EloquentFeatureRepositoryTest.php
@@ -16,7 +16,7 @@ class EloquentFeatureRepositoryTest extends TestCase
     /** @var EloquentFeatureRepository */
     private $repository;
 
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
 
@@ -35,6 +35,20 @@ class EloquentFeatureRepositoryTest extends TestCase
         $this->assertDatabaseHas('features', [
             'name' => 'my.feature',
             'is_enabled' => true
+        ]);
+    }
+
+    public function testSaveDoesNotModifyStatusOfExistingFeatures()
+    {
+        $feature = Feature::fromNameAndStatus('my.first.feature', true);
+        $scannedFeature = Feature::fromNameAndStatus('my.first.feature', false);
+        $this->repository->save($feature);
+
+        $this->repository->save($scannedFeature);
+
+        $this->assertDatabaseHas('features', [
+            'name' => 'my.first.feature',
+            'is_enabled' => true,
         ]);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description



## Motivation and context

With config('features.scanned_default_enabled'), running php artisan feature:scan in a pipeline becomes destructive since it will reset any scanned feature flags that have been modified to whatever the value of scanned_default_enabled is.

After running php artisan feature:scan, the views directory is scanned and the features are printed with the below message.

All the new features were added to the database with the disabled status by default. Nothing changed for the already present ones.

The last statement is misleading as it resets existing features to the default value.

## How has this been tested?

Run the following to execute the test for this behavior: vendor/bin/phpunit --filter testSaveDoesNotModifyStatusOfExistingFeatures

Removing $model->is_enabled ?? from EloquentFeatureRepository@save brings the test back to failing and reverts to the original behavior.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
