### PR TITLE
reverted changes and moved functionality to only the scanner command

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -32,7 +32,7 @@
     <logging>
         <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-html" target="build/coverage"/>
         <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>

--- a/src/Domain/FeatureManager.php
+++ b/src/Domain/FeatureManager.php
@@ -20,6 +20,11 @@ class FeatureManager
         $this->repository = $repository;
     }
 
+    public function exists($featureName)
+    {
+        return $this->repository->exists($featureName);
+    }
+
     public function add($featureName, $isEnabled)
     {
         $feature = Feature::fromNameAndStatus($featureName, $isEnabled);

--- a/src/Domain/Repository/FeatureRepositoryInterface.php
+++ b/src/Domain/Repository/FeatureRepositoryInterface.php
@@ -7,6 +7,8 @@ use LaravelFeature\Featurable\FeaturableInterface;
 
 interface FeatureRepositoryInterface
 {
+    public function exists($featureName);
+
     public function save(Feature $feature);
 
     public function remove(Feature $feature);

--- a/src/Repository/EloquentFeatureRepository.php
+++ b/src/Repository/EloquentFeatureRepository.php
@@ -20,7 +20,7 @@ class EloquentFeatureRepository implements FeatureRepositoryInterface
         }
 
         $model->name = $feature->getName();
-        $model->is_enabled = $model->is_enabled ?? $feature->isEnabled();
+        $model->is_enabled = $feature->isEnabled();
 
         try {
             $model->save();

--- a/src/Repository/EloquentFeatureRepository.php
+++ b/src/Repository/EloquentFeatureRepository.php
@@ -10,6 +10,11 @@ use LaravelFeature\Model\Feature as Model;
 
 class EloquentFeatureRepository implements FeatureRepositoryInterface
 {
+    public function exists($featureName)
+    {
+        return Model::where('name', '=', $featureName)->exists();
+    }
+
     public function save(Feature $feature)
     {
         /** @var Model $model */

--- a/src/Service/FeaturesViewScanner.php
+++ b/src/Service/FeaturesViewScanner.php
@@ -42,7 +42,9 @@ class FeaturesViewScanner
         $foundDirectives = array_unique($foundDirectives);
 
         foreach ($foundDirectives as $directive) {
-            $this->featureManager->add($directive, $this->config->get('features.scanned_default_enabled'));
+            if (!$this->featureManager->isEnabled($directive)) {
+                $this->featureManager->add($directive, $this->config->get('features.scanned_default_enabled'));
+            }
         }
 
         return $foundDirectives;

--- a/src/Service/FeaturesViewScanner.php
+++ b/src/Service/FeaturesViewScanner.php
@@ -42,7 +42,7 @@ class FeaturesViewScanner
         $foundDirectives = array_unique($foundDirectives);
 
         foreach ($foundDirectives as $directive) {
-            if (!$this->featureManager->isEnabled($directive)) {
+            if (!$this->featureManager->exists($directive)) {
                 $this->featureManager->add($directive, $this->config->get('features.scanned_default_enabled'));
             }
         }

--- a/tests/Integration/Repository/EloquentFeatureRepositoryTest.php
+++ b/tests/Integration/Repository/EloquentFeatureRepositoryTest.php
@@ -38,20 +38,6 @@ class EloquentFeatureRepositoryTest extends TestCase
         ]);
     }
 
-    public function testSaveDoesNotModifyStatusOfExistingFeatures()
-    {
-        $feature = Feature::fromNameAndStatus('my.first.feature', true);
-        $scannedFeature = Feature::fromNameAndStatus('my.first.feature', false);
-        $this->repository->save($feature);
-
-        $this->repository->save($scannedFeature);
-
-        $this->assertDatabaseHas('features', [
-            'name' => 'my.first.feature',
-            'is_enabled' => true,
-        ]);
-    }
-
     /**
      * Tests that the save operation throws an exception if something goes wrong.
      *

--- a/tests/Integration/Repository/EloquentFeatureRepositoryTest.php
+++ b/tests/Integration/Repository/EloquentFeatureRepositoryTest.php
@@ -50,6 +50,19 @@ class EloquentFeatureRepositoryTest extends TestCase
         $this->repository->save($feature);
     }
 
+    public function testFeatureCanBeCheckedForExistence()
+    {
+        $feature = Feature::fromNameAndStatus('my.feature', false);
+        $this->repository->save($feature);
+
+        $this->assertTrue($this->repository->exists('my.feature'));
+    }
+
+    public function testFeatureCanBeCheckedForNonExistence()
+    {
+        $this->assertFalse($this->repository->exists('my.feature'));
+    }
+
     /**
      * Tests that the removal operation goes well.
      */

--- a/tests/Unit/Domain/FeatureManagerTest.php
+++ b/tests/Unit/Domain/FeatureManagerTest.php
@@ -55,6 +55,14 @@ class FeatureManagerTest extends TestCase
         $this->manager->add('my.feature', true);
     }
 
+    public function testExists()
+    {
+        $this->repositoryMock->expects($this->once())
+            ->method('exists');
+
+        $this->manager->exists('my.new.feature');
+    }
+
     /**
      * Tests that everything goes well during a feature removal.
      */

--- a/tests/Unit/Domain/FeatureManagerTest.php
+++ b/tests/Unit/Domain/FeatureManagerTest.php
@@ -22,7 +22,7 @@ class FeatureManagerTest extends TestCase
         parent::setUp();
 
         $this->repositoryMock = $this->getMockBuilder(FeatureRepositoryInterface::class)
-            ->setMethods(['save', 'remove', 'findByName', 'enableFor', 'disableFor', 'isEnabledFor'])
+            ->setMethods(['exists', 'save', 'remove', 'findByName', 'enableFor', 'disableFor', 'isEnabledFor'])
             ->disableOriginalConstructor()
             ->getMock();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Existing features are now editable again.

## Motivation and context

Original PR made it so that existing features could not be toggled.

## How has this been tested?

Instead of passing all found features, we now only pass in scanned features that are not enabled.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
